### PR TITLE
(GH-31) switch to Force-Publish-Documentation for the gh-workfow

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ test: off
 build: off
 
 build_script:
-  - ps: .\build.ps1 --target=CI
+  - ps: .\build.ps1 --target=CI --verbosity=Diagnostic
 
 cache:
   - "tools -> recipe.cake"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v2.3.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.ref }}
       - name: Cache Tools
         uses: actions/cache@v2
         with:

--- a/.github/workflows/publishDocs.yml
+++ b/.github/workflows/publishDocs.yml
@@ -1,8 +1,6 @@
 name: Publish Documentation
 
 on:
-  push:
-    branches: [ develop ]
   workflow_dispatch:
 
 env:
@@ -13,7 +11,7 @@ env:
 
 jobs:
   cake:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: checkout
@@ -23,7 +21,7 @@ jobs:
         ref: ${{ github.event.ref }}
     
     - name: Cache Tools
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.1
       with:
         path: tools
         key: ${{ runner.os }}-doc-tools-${{ hashFiles('recipe.cake') }}
@@ -32,7 +30,7 @@ jobs:
       uses: cake-build/cake-action@v1
       with:
         script-path: recipe.cake
-        target: PublishDocs
+        target: Force-Publish-Documentation
         verbosity: Diagnostic
         cake-version: 0.38.4
         cake-bootstrap: true

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins%40Local/nuget/v3/index.json?package=Cake.Recipe&version=2.0.0-alpha0461&prerelease
+#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins%40Local/nuget/v3/index.json?package=Cake.Recipe&version=2.0.0-alpha0471&prerelease
 
 Environment.SetVariableNames();
 
@@ -9,7 +9,7 @@ BuildParameters.SetParameters(
     title: "Cake.AsciiDoctorJ",
     masterBranchName: "main",
     repositoryOwner: "cake-contrib",
-    repositoryName: "Cake.AsciiDoctorJ",
+    repositoryName: "cake.asciidoctorj",
     appVeyorAccountName: "cakecontrib",
     shouldRunDotNetCorePack: true,
     shouldUseDeterministicBuilds: true);


### PR DESCRIPTION
and removed the push trigger on that workflow because publishing
shoud now work without problems on AppVeyor.